### PR TITLE
Add repo link to OCI logo

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -40,7 +40,7 @@
       logos: [
         {
           src: "https://avatars.githubusercontent.com/u/79323216?s=200&v=4",
-          url: "REPO_LINK",
+          url: "https://github.com/Open-Credentialing-Initiative/policies-and-architecture",
           alt: "OCI Logo",
           width: 100,
           height: 100,


### PR DESCRIPTION
The current link behind the OCI logo sends you to a broken link. This should add the correct repository link.